### PR TITLE
release script: ensure archive is output to cwd

### DIFF
--- a/scripts/ztp-release.sh
+++ b/scripts/ztp-release.sh
@@ -85,9 +85,10 @@ function main() {
     echo "tagging as ${RELEASE_VERSION_TAG}"
     git tag ${RELEASE_VERSION_TAG} ${FORCE} >& ${REDIRECT}
     git push origin refs/tags/${RELEASE_VERSION_TAG} ${FORCE} >& ${REDIRECT}
+    pushd -0 && dirs -c
 
     echo "preparing release archive"
-    git config tar.tar.xz "xz -c"
+    git config tar.tar.xz.command "xz -c"
     git archive --format=tar.xz --prefix=${RELEASE_NAME}/ ${RELEASE_VERSION_TAG} > ${RELEASE_ARCHIVE}
     echo "created release archive ${RELEASE_ARCHIVE} -> $(sha256sum ${RELEASE_ARCHIVE} | awk '{print $1}')"
 }


### PR DESCRIPTION
### Type
- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [X] Infrastructure

### Goals
Ensure release script can be used outside the context of GitHub.

### Technical Details
Fix release script to:
* Configure xz-compression command for git.
* Output archive to cwd.

### Test Results
* Executed release script with typical args and verified newly created tag was present and archive available in cwd.

### Reviewer Focus
* None

### Future Work
* None

### Checklist
- [X] Build target `all` compiles cleanly.
- [X] cppcheck produces no output.
- [X] clang-format delta produced no new output.
- [X] Newly added functions include doxygen-style comment block
