### PR TITLE
Add parallel make flag to example build command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ git clone git@github.com:microsoft/wifi-ztp.git
 cd wifi-ztp
 mkdir build && cd $_
 cmake ..
-make
+make -j $(nproc)
 ```
 
 ## Contributing


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [X] Documentation
- [ ] Infrastructure

### Goals

Ensure build examples make use of multiple prorcessors.

### Technical Details

- Add parallel make flag to build command.

### Test Results

- N/A

### Reviewer Focus

- None

### Future Work

-None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] cppcheck produces no output.
- [X] clang-format delta produced no new output.
- [X] Newly added functions include doxygen-style comment block.
