### PR TITLE
Fix buffer overflow issue in __wpa_controller_send_commandf()

### DIFF
--- a/src/wpas/wpa_controller.c
+++ b/src/wpas/wpa_controller.c
@@ -820,8 +820,9 @@ __wpa_controller_send_commandf(struct wpa_controller *ctrl, const char *name, ch
 int
 wpa_controller_qrcode(struct wpa_controller *ctrl, const char *dpp_uri, uint32_t *bootstrap_id)
 {
-    char reply[WPA_MAX_MSG_SIZE];
-    size_t reply_length = sizeof reply;
+    char reply[WPA_MAX_MSG_SIZE + 1];
+    explicit_bzero(reply, sizeof reply);
+    size_t reply_length = WPA_MAX_MSG_SIZE;
 
     int ret = wpa_controller_send_commandf(ctrl, "DPP_QR_CODE", reply, &reply_length, "%s", dpp_uri);
     if (ret < 0)
@@ -975,8 +976,9 @@ wpa_controller_dpp_bootstrap_set(struct wpa_controller *ctrl, uint32_t peer_id, 
 int
 wpa_controller_dpp_bootstrap_gen(struct wpa_controller *ctrl, const struct dpp_bootstrap_info *bi, uint32_t *id)
 {
-    char reply[WPA_MAX_MSG_SIZE];
-    size_t reply_length = sizeof reply;
+    char reply[WPA_MAX_MSG_SIZE + 1];
+    explicit_bzero(reply,sizeof reply);
+    size_t reply_length = WPA_MAX_MSG_SIZE;
 
     int ret = wpa_controller_send_commandf(ctrl, "DPP_BOOTSTRAP_GEN", reply, &reply_length, 
         "type=%s %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s",

--- a/src/wpas/wpa_controller.c
+++ b/src/wpas/wpa_controller.c
@@ -758,9 +758,14 @@ wpa_controller_destroy(struct wpa_controller **ctrl)
 static int
 __wpa_controller_send_commandf(struct wpa_controller *ctrl, const char *name, char *reply, size_t *reply_length, const char *fmt, ...)
 {
+    if(reply_length == NULL) {
+        zlog_error_if(ctrl->interface, "reply_length is a NULL-pointer");
+        return -1;
+    }
+
     if (*reply_length == 0) {
         zlog_error_if(ctrl->interface, "buffer size doesn't have space for the null terminator");
-        return -1;
+        return -ENOMEM;
     }
 
     int ret;

--- a/src/wpas/wpa_controller.c
+++ b/src/wpas/wpa_controller.c
@@ -784,7 +784,7 @@ __wpa_controller_send_commandf(struct wpa_controller *ctrl, const char *name, ch
         zlog_error_if(ctrl->interface, "failed to send %s command on ctrl interface (%d)", name, ret);
         return ret;
     }
-    reply[*reply_length] = '\0';
+    reply[*reply_length > WPA_MAX_MSG_SIZE? WPA_MAX_MSG_SIZE : *reply_length] = '\0';
 
     zlog_debug_if(ctrl->interface, "wpa <- %.*s", (int)(*reply_length), reply);
 

--- a/src/wpas/wpa_controller.c
+++ b/src/wpas/wpa_controller.c
@@ -301,7 +301,7 @@ wpa_controller_process_event_dpp_configuration_success(struct wpa_controller *ct
 static void
 wpa_controller_process_event(struct wpa_controller *ctrl)
 {
-    char buf[WPA_MAX_MSG_SIZE];
+    char buf[WPA_MAX_MSG_SIZE + 1];
     size_t buf_length = (sizeof buf) - 1;
 
     int ret = wpa_ctrl_recv(ctrl->event, buf, &buf_length);
@@ -759,7 +759,7 @@ static int
 __wpa_controller_send_commandf(struct wpa_controller *ctrl, const char *name, char *reply, size_t *reply_length, const char *fmt, ...)
 {
     int ret;
-    char cmd[WPA_MAX_MSG_SIZE];
+    char cmd[WPA_MAX_MSG_SIZE + 1];
 
     if (!ctrl->connected) {
         zlog_error_if(ctrl->interface, "no connection to control interface");
@@ -860,7 +860,7 @@ wpa_controller_qrcode(struct wpa_controller *ctrl, const char *dpp_uri, uint32_t
 int
 wpa_controller_set(struct wpa_controller *ctrl, const char *key, const char *value)
 {
-    char reply[WPA_MAX_MSG_SIZE];
+    char reply[WPA_MAX_MSG_SIZE + 1];
     size_t reply_length = sizeof reply;
 
     int ret = wpa_controller_send_commandf(ctrl, "SET", reply, &reply_length, "%s %s", key, value);
@@ -888,7 +888,7 @@ int
 wpa_controller_dpp_auth_init(struct wpa_controller *ctrl, uint32_t peer_id, uint32_t frequency)
 {
     int ret;
-    char reply[WPA_MAX_MSG_SIZE];
+    char reply[WPA_MAX_MSG_SIZE + 1];
     size_t reply_length = sizeof reply;
 
     if (frequency > 0) {
@@ -923,7 +923,7 @@ int
 wpa_controller_dpp_auth_init_with_conf(struct wpa_controller *ctrl, uint32_t peer_id, uint32_t frequency, const char *conf)
 {
     int ret;
-    char reply[WPA_MAX_MSG_SIZE];
+    char reply[WPA_MAX_MSG_SIZE + 1];
     size_t reply_length = sizeof reply;
 
     if (frequency > 0) {
@@ -953,7 +953,7 @@ wpa_controller_dpp_auth_init_with_conf(struct wpa_controller *ctrl, uint32_t pee
 int
 wpa_controller_dpp_bootstrap_set(struct wpa_controller *ctrl, uint32_t peer_id, const char *conf)
 {
-    char reply[WPA_MAX_MSG_SIZE];
+    char reply[WPA_MAX_MSG_SIZE + 1];
     size_t reply_length = sizeof reply;
 
     int ret = wpa_controller_send_commandf(ctrl, "DPP_BOOTSTRAP_SET", reply, &reply_length, "%" PRIu32 " %s", peer_id, conf);
@@ -1016,7 +1016,7 @@ wpa_controller_dpp_bootstrap_gen(struct wpa_controller *ctrl, const struct dpp_b
 int
 wpa_controller_dpp_chirp(struct wpa_controller *ctrl, uint32_t bootstrap_key_id, uint32_t iterations)
 {
-    char reply[WPA_MAX_MSG_SIZE];
+    char reply[WPA_MAX_MSG_SIZE + 1];
     size_t reply_length = sizeof reply;
 
     int ret = wpa_controller_send_commandf(ctrl, "DPP_CHIRP", reply, &reply_length, "own=%" PRIu32 " iter=%" PRIu32, bootstrap_key_id, iterations);
@@ -1035,7 +1035,7 @@ wpa_controller_dpp_chirp(struct wpa_controller *ctrl, uint32_t bootstrap_key_id,
 int
 wpa_controller_dpp_chirp_stop(struct wpa_controller *ctrl)
 {
-    char reply[WPA_MAX_MSG_SIZE];
+    char reply[WPA_MAX_MSG_SIZE + 1];
     size_t reply_length = sizeof reply;
 
     int ret = wpa_controller_send_command(ctrl, "DPP_STOP_CHIRP", reply, &reply_length);
@@ -1052,7 +1052,7 @@ wpa_controller_dpp_chirp_stop(struct wpa_controller *ctrl)
 int
 wpa_controller_dpp_listen_stop(struct wpa_controller *ctrl)
 {
-    char reply[WPA_MAX_MSG_SIZE];
+    char reply[WPA_MAX_MSG_SIZE + 1];
     size_t reply_length = sizeof reply;
 
     int ret = wpa_controller_send_command(ctrl, "DPP_STOP_LISTEN", reply, &reply_length);

--- a/src/wpas/wpa_controller.c
+++ b/src/wpas/wpa_controller.c
@@ -821,12 +821,13 @@ int
 wpa_controller_qrcode(struct wpa_controller *ctrl, const char *dpp_uri, uint32_t *bootstrap_id)
 {
     char reply[WPA_MAX_MSG_SIZE + 1];
-    explicit_bzero(reply, sizeof reply);
     size_t reply_length = WPA_MAX_MSG_SIZE;
 
     int ret = wpa_controller_send_commandf(ctrl, "DPP_QR_CODE", reply, &reply_length, "%s", dpp_uri);
     if (ret < 0)
         return ret;
+
+    reply[reply_length] = '\0';
 
     uint32_t id = (uint32_t)strtoul(reply, NULL, 10);
     if (id == 0) {
@@ -977,7 +978,6 @@ int
 wpa_controller_dpp_bootstrap_gen(struct wpa_controller *ctrl, const struct dpp_bootstrap_info *bi, uint32_t *id)
 {
     char reply[WPA_MAX_MSG_SIZE + 1];
-    explicit_bzero(reply,sizeof reply);
     size_t reply_length = WPA_MAX_MSG_SIZE;
 
     int ret = wpa_controller_send_commandf(ctrl, "DPP_BOOTSTRAP_GEN", reply, &reply_length, 
@@ -993,6 +993,8 @@ wpa_controller_dpp_bootstrap_gen(struct wpa_controller *ctrl, const struct dpp_b
         bi->engine_path  ? " engine_path=" : "", bi->engine_path ? bi->engine_path : "");
     if (ret < 0)
         return ret;
+
+    reply[reply_length] = '\0';
 
     uint32_t id_reply = (uint32_t)strtoul(reply, NULL, 0);
     if (id_reply == 0)

--- a/src/wpas/wpa_controller.c
+++ b/src/wpas/wpa_controller.c
@@ -758,8 +758,8 @@ wpa_controller_destroy(struct wpa_controller **ctrl)
 static int
 __wpa_controller_send_commandf(struct wpa_controller *ctrl, const char *name, char *reply, size_t *reply_length, const char *fmt, ...)
 {
-    if (*reply_length==0) {
-        zlog_error_if(ctrl->interface, "buffer size doesn't have space for the null byte");
+    if (*reply_length == 0) {
+        zlog_error_if(ctrl->interface, "buffer size doesn't have space for the null terminator");
         return -1;
     }
 

--- a/src/wpas/wpa_controller.c
+++ b/src/wpas/wpa_controller.c
@@ -785,7 +785,7 @@ __wpa_controller_send_commandf(struct wpa_controller *ctrl, const char *name, ch
     zlog_debug_if(ctrl->interface, "wpa -> %.*s", (int)cmd_length, cmd);
 
     // exclude the null byte from the buffer size
-    *reply_length = *reply_length-1;
+    *reply_length = *reply_length - 1;
 
     // wpa_ctrl_request will stop reading at *reply_length bytes, ensuring buffer safety
     ret = wpa_ctrl_request(ctrl->command, cmd, cmd_length, reply, reply_length, NULL);


### PR DESCRIPTION
### Type

- [x] Bug fix

### Goals

Resolve the issue where strtoul reads past the reply_length and returns an integer that is not what wpa replied with

### Technical Details

* explicit_bzero the buffer before using it. We could also set the null terminator byte after we know the reply_length, but explicit_bzero should take roughly the same amount of time because of cache blocks.
* Make the buffer WPA_MAX_MSG_SIZE + 1 chars long so in the (extremely rare) case that the reply length is WPA_MAX_MSG_SIZE the buffer can also hold a null terminator.

### Test Results

- [X] enrollee using ztpd, configurator using ztpd

### Reviewer Focus
None.

### Future Work

There may be other places in the code where we need to do this sort of thing with the wpa reply buffer.
