### PR TITLE
Remove object prefix and add mac addresses.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ This bootstrapping information provider sources enrollee bootstrapping records f
     "ZeroTouchProvisioning": {
         "WiFi": {
             "Interfaces": [
-                "wlan0": {
-                    "DppUri": "DPP:V:2;K:MDkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDIgACE0vdn8KsfXKHusJPcEscx+naQyQJLSob1VjuqPsP6r8=;;"
+                {
+                    "DppUri": "DPP:V:2;M:d8c0a65935ed;K:MDkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDIgACE0vdn8KsfXKHusJPcEscx+naQyQJLSob1VjuqPsP6r8=;;"
                 },
-                "wlan1": {
-                    "DppUri": "DPP:V:2;K:MDkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDIgACiLN+2Rk4tRlwl4CKYkSEdheJIEbZO5UBr9SPoPFI394=;;"
+                {
+                    "DppUri": "DPP:V:2;M:70665509b591;K:MDkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDIgACiLN+2Rk4tRlwl4CKYkSEdheJIEbZO5UBr9SPoPFI394=;;"
                 }
             ]
         }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [X] Documentation
- [ ] Infrastructure

### Goals

Ensure Azure DPS bootstrap information provider device record examples are accurate and demonstrate how the URIs can be assigned to different devices.

### Technical Details

Add mac addresses to the DPP URIs in the DPS bootstrap information provider examples. 

### Test Results

- N/A

### Reviewer Focus

- None

### Future Work

- None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] cppcheck produces no output.
- [X] clang-format delta produced no new output.
- [X] Newly added functions include doxygen-style comment block.
