### PR TITLE
Fix some misspellings

### DIFF
--- a/src/core/ztp_wpa_supplicant.c
+++ b/src/core/ztp_wpa_supplicant.c
@@ -224,7 +224,7 @@ wpas_interface_added(sd_bus_message *msg, void *userdata, sd_bus_error *ret_erro
 
     ret = wpas_interface_add(wpas, path, name);
     if (ret < 0) {
-        zlog_error("[%s] failed to add new interface (%d)", name, ret);
+        zlog_error_if(name, "failed to add new interface (%d)", ret);
         return ret;
     }
 

--- a/src/wpas/wpa_controller.c
+++ b/src/wpas/wpa_controller.c
@@ -65,7 +65,7 @@ struct wpa_event_handler_instance {
 static_assert(MAC_SIZE == MAC_SIZE_C, "invalid mac size");
 
 /**
- * @brief Helpers for pasing a DPP bootstrap hash string as encoded in wpa
+ * @brief Helpers for parsing a DPP bootstrap hash string as encoded in wpa
  * control socket event messages.
  */
 #define DPP_HASH_FORMAT "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
@@ -98,7 +98,7 @@ wpa_controller_process_event_chirp_received(struct wpa_controller *ctrl, const c
 
     struct dpp_bootstrap_publickey_hash publickey_hash;
     if (hex_decode(hash, publickey_hash.data, sizeof publickey_hash.data) < 0) {
-        zlog_error_if(ctrl->interface, "ifailed to decode public key hash (invalid format)");
+        zlog_error_if(ctrl->interface, "failed to decode public key hash (invalid format)");
         return;
     }
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [X] Documentation
- [ ] Infrastructure

### Goals

Ensure there are no misspelled words and that appropriate logging macros are used for messages that are interface-bound.

### Technical Details

- Fix spelling.
- Update logging to use `_if()` macro variants when an interface is involved.

### Test Results

None

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] cppcheck produces no output.
- [X] clang-format delta produced no new output.
- [X] Newly added functions include doxygen-style comment block.
