### PR TITLE
address memory leak in main.c

### DIFF
--- a/src/ztpd/main.c
+++ b/src/ztpd/main.c
@@ -314,18 +314,19 @@ main(int argc, char *argv[])
     if (daemonize) {
         if (daemon(0, 0)) {
             zlog_panic("failed to daemonize");
-            return -1;
+            ret = -1;
+            goto cleanup;
         }
     }
 
     ret = ztpd_run(&ztpd);
     if (ret < 0) {
         zlog_panic("ztpd did not exit cleanly (%d)", ret);
-        return ret;
+    } else {
+        zlog_debug("event loop completed");
     }
 
-    zlog_debug("event loop completed");
-
+cleanup:
     ztpd_uninitialize(&ztpd);
     ztp_dbus_uninitialize(&dbus_client);
     ztp_dbus_server_uninitialize(&dbus_server);
@@ -335,6 +336,6 @@ main(int argc, char *argv[])
     close(signalfd);
 
     zlog_debug("exiting");
-
-    return 0;
+out:
+    return ret;
 }

--- a/src/ztpd/main.c
+++ b/src/ztpd/main.c
@@ -336,6 +336,5 @@ cleanup:
     close(signalfd);
 
     zlog_debug("exiting");
-out:
     return ret;
 }


### PR DESCRIPTION
### Type

- [x] Bug fix

### Goals

Address #25.


### Technical Details

In the main.c, make sure we cleanup whenever we attempt to return. The only places where this seems to be the case are if ztpd_run fails or if daemonze() fails.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] cppcheck produces no output.
- [x] clang-format delta produced no new output.
- [x] Newly added functions include doxygen-style comment block.
